### PR TITLE
Update README with details about alternative solution for later versions of Dimensions CM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-Serena Pulse
-============
+Dimensions CM 14.1 Pulse
+========================
 
-Plugin to send an external event to Serena Pulse.
+Plugin to send an external event to [Dimensions CM](http://www.serena.com/dimensions-cm) 14.1 Pulse.
 
-See the file pulse-event.json for an example Generic Process (created in Serena Release Automation 5.1)
+See the file `pulse-event.json` for an example Generic Process (created in Serena Release Automation 5.1).
+
+**NOTE** - for Dimensions CM 14.2 or later, use Pulse's _SDA Deployment expert_ or _SDA Generic Process expert_ instead.


### PR DESCRIPTION
Minor change to README to mention using the Pulse experts in CM 14.2 or later.
